### PR TITLE
Fix For loops on the dynamic builder path

### DIFF
--- a/src/Orsak/EffectBuilder.fs
+++ b/src/Orsak/EffectBuilder.fs
@@ -3559,17 +3559,21 @@ module Medium =
 
                                 this.While(
                                     (fun () -> continue'),
-                                    let current = enumerator.Current
-
-                                    this.Combine(
-                                        (f1 current),
-                                        this.Bind(
-                                            enumerator.MoveNextAsync(),
-                                            fun b ->
-                                                continue' <- b
-                                                this.Zero()
-                                        )
-                                    )
+                                    // Both the read of Current and the advance belong inside the loop body,
+                                    // one per iteration. Delay defers them to each invocation - without it
+                                    // the dynamic path reads Current once and awaits a single MoveNextAsync
+                                    // forever.
+                                    this.Delay(fun () ->
+                                        this.Combine(
+                                            (f1 enumerator.Current),
+                                            this.Delay(fun () ->
+                                                this.Bind(
+                                                    enumerator.MoveNextAsync(),
+                                                    fun b ->
+                                                        continue' <- b
+                                                        this.Zero()
+                                                ))
+                                        ))
                                 )
                         )
                 ))
@@ -3591,13 +3595,16 @@ module Medium =
                                     this.Delay(fun () ->
                                         this.Combine(
                                             (f enumerator.Current),
-                                            this.Bind(
-                                                enumerator.MoveNextAsync(),
-                                                fun b ->
-                                                    let y = b
-                                                    continue' <- y
-                                                    this.Zero()
-                                            )
+                                            // Delayed so the enumerator is advanced after the body has run,
+                                            // not while the dynamic path is building the loop body.
+                                            this.Delay(fun () ->
+                                                this.Bind(
+                                                    enumerator.MoveNextAsync(),
+                                                    fun b ->
+                                                        let y = b
+                                                        continue' <- y
+                                                        this.Zero()
+                                                ))
                                         ))
                                 )
                         )
@@ -3653,7 +3660,15 @@ module Medium =
             this.Delay(fun () ->
                 this.Using(
                     s.GetEnumerator(),
-                    fun enumerator -> this.While((fun () -> enumerator.MoveNext()), (f1 enumerator.Current))
+                    fun enumerator ->
+                        // Current must be read inside the loop body. While invokes the body value once
+                        // per iteration, so on the dynamic path anything evaluated while constructing the
+                        // body is hoisted out of the loop - here that would read Current before the first
+                        // MoveNext.
+                        this.While(
+                            (fun () -> enumerator.MoveNext()),
+                            EffectCode<'Env, 'TOverall, unit, 'Err>(fun sm -> (f1 enumerator.Current).Invoke(&sm))
+                        )
                 ))
 
         member inline this.For

--- a/src/Orsak/ValueTaskBuilder.fs
+++ b/src/Orsak/ValueTaskBuilder.fs
@@ -368,15 +368,20 @@ module LowPriority =
 
                                 this.While(
                                     (fun () -> cont),
-                                    this.Combine(
-                                        body enum.Current,
-                                        this.Bind(
-                                            enum.MoveNextAsync(),
-                                            fun b ->
-                                                cont <- b
-                                                this.Zero()
-                                        )
-                                    )
+                                    // Reading Current and advancing the enumerator both belong inside the
+                                    // loop body. Delay defers them to each invocation - without it the
+                                    // dynamic path evaluates them once, while building the body.
+                                    this.Delay(fun () ->
+                                        this.Combine(
+                                            body enum.Current,
+                                            this.Delay(fun () ->
+                                                this.Bind(
+                                                    enum.MoveNextAsync(),
+                                                    fun b ->
+                                                        cont <- b
+                                                        this.Zero()
+                                                ))
+                                        ))
                                 )
                         )
                 ))

--- a/tests/Orsak.Tests/ForLoopTests.fs
+++ b/tests/Orsak.Tests/ForLoopTests.fs
@@ -1,0 +1,120 @@
+module Orsak.Tests.ForLoopTests
+
+open System.Collections.Generic
+open System.Threading.Tasks
+open Orsak
+open Xunit
+
+let private record (seen: ResizeArray<'a>) (x: 'a) : Effect<unit, unit, string> =
+    mkEffect (fun _ ->
+        seen.Add x
+        ValueTask.FromResult(Ok()))
+
+/// Builds `for x in items do do! f x` by calling the builder members directly, with the
+/// loop body as a first-class function value rather than an inline lambda. That places a
+/// resumption point inside a non-inlined closure, so the state machine cannot be compiled
+/// statically and `Run` falls back to the dynamic path - the same path an ordinary
+/// `eff { for .. in .. do }` takes whenever the compiler reports FS3511 for the block.
+///
+/// The FS3501 ("must be marked 'inline'") and FS3511 ("not statically compilable") warnings
+/// on the two helpers below are expected, and are what makes these tests meaningful: if they
+/// ever stop being reported, the loops compile statically and no longer cover the dynamic
+/// implementation of For. Do not silence them.
+let private dynamicFor (items: seq<'a>) (f: 'a -> Effect<unit, unit, string>) =
+    let body = fun x -> eff.ReturnFrom(f x)
+    eff.Run(eff.Delay(fun () -> eff.For(items, body)))
+
+let private dynamicForAsync (items: IAsyncEnumerable<'a>) (f: 'a -> Effect<unit, unit, string>) =
+    let body = fun x -> eff.ReturnFrom(f x)
+    eff.Run(eff.Delay(fun () -> eff.For(items, body)))
+
+let private asyncSeq (items: 'a list) : IAsyncEnumerable<'a> =
+    { new IAsyncEnumerable<'a> with
+        member _.GetAsyncEnumerator(_) =
+            let remaining = ref items
+            let current = ref Unchecked.defaultof<'a>
+
+            { new IAsyncEnumerator<'a> with
+                member _.Current = current.Value
+
+                member _.MoveNextAsync() =
+                    match remaining.Value with
+                    | [] -> ValueTask.FromResult false
+                    | x :: rest ->
+                        current.Value <- x
+                        remaining.Value <- rest
+                        ValueTask.FromResult true
+
+                member _.DisposeAsync() = ValueTask.CompletedTask }
+    }
+
+/// The same loops in ordinary `for .. in .. do` syntax. Which state machine these compile to
+/// is the compiler's choice and has changed between SDK versions - dotnet 10.0.400 moved blocks
+/// like these onto the dynamic path, which is how the For bugs surfaced in the first place. On a
+/// toolchain that compiles them statically they pass whatever For does, so they are a guard for
+/// future toolchains rather than a reproduction; the dynamicFor tests above are the reproduction.
+let private plainFor (items: seq<'a>) (f: 'a -> Effect<unit, unit, string>) = eff {
+    for x in items do
+        do! f x
+}
+
+let private plainForAsync (items: IAsyncEnumerable<'a>) (f: 'a -> Effect<unit, unit, string>) = eff {
+    for x in items do
+        do! f x
+}
+
+[<Fact>]
+let ``for over an F# list on the dynamic path visits every element`` () = task {
+    let seen = ResizeArray()
+    do! dynamicFor [ 1; 2; 3 ] (record seen) |> Effect.runOrFail ()
+    Assert.Equal<int list>([ 1; 2; 3 ], List.ofSeq seen)
+}
+
+[<Fact>]
+let ``for over a ResizeArray on the dynamic path visits every element`` () = task {
+    let seen = ResizeArray()
+    do! dynamicFor (ResizeArray [ "a"; "b"; "c" ]) (record seen) |> Effect.runOrFail ()
+    Assert.Equal<string list>([ "a"; "b"; "c" ], List.ofSeq seen)
+}
+
+[<Fact>]
+let ``for over an empty sequence on the dynamic path runs the body zero times`` () = task {
+    let seen = ResizeArray()
+    do! dynamicFor List.empty<int> (record seen) |> Effect.runOrFail ()
+    Assert.Empty seen
+}
+
+[<Fact>]
+let ``for over an IAsyncEnumerable on the dynamic path visits every element`` () = task {
+    let seen = ResizeArray()
+    do! dynamicForAsync (asyncSeq [ 1; 2; 3 ]) (record seen) |> Effect.runOrFail ()
+    Assert.Equal<int list>([ 1; 2; 3 ], List.ofSeq seen)
+}
+
+[<Fact>]
+let ``for over an F# list visits every element`` () = task {
+    let seen = ResizeArray()
+    do! plainFor [ 1; 2; 3 ] (record seen) |> Effect.runOrFail ()
+    Assert.Equal<int list>([ 1; 2; 3 ], List.ofSeq seen)
+}
+
+[<Fact>]
+let ``for over a ResizeArray visits every element`` () = task {
+    let seen = ResizeArray()
+    do! plainFor (ResizeArray [ "a"; "b"; "c" ]) (record seen) |> Effect.runOrFail ()
+    Assert.Equal<string list>([ "a"; "b"; "c" ], List.ofSeq seen)
+}
+
+[<Fact>]
+let ``for over an empty sequence runs the body zero times`` () = task {
+    let seen = ResizeArray()
+    do! plainFor List.empty<int> (record seen) |> Effect.runOrFail ()
+    Assert.Empty seen
+}
+
+[<Fact>]
+let ``for over an IAsyncEnumerable visits every element`` () = task {
+    let seen = ResizeArray()
+    do! plainForAsync (asyncSeq [ 1; 2; 3 ]) (record seen) |> Effect.runOrFail ()
+    Assert.Equal<int list>([ 1; 2; 3 ], List.ofSeq seen)
+}

--- a/tests/Orsak.Tests/Orsak.Tests.fsproj
+++ b/tests/Orsak.Tests/Orsak.Tests.fsproj
@@ -20,6 +20,7 @@
         <Compile Include="RecoveryTests.fs"/>
         <Compile Include="Tests.fs"/>
         <Compile Include="TailCallTests.fs"/>
+        <Compile Include="ForLoopTests.fs"/>
         <Compile Include="WhenAllTests.fs"/>
         <Compile Include="ScopedTests.fs"/>
         <Compile Include="MyriadTests.fs"/>


### PR DESCRIPTION
The dynamic implementation of While invokes the loop body value once per iteration, so anything evaluated while *constructing* that body is hoisted out of the loop. Three For overloads evaluated per-iteration work eagerly:

This issue went unnoticed until I upgraded to use the 10.0.400 SDK. Then my application using Orsak started failing with the error message `System.InvalidOperationException: Enumeration has not started. Call MoveNext.`.

I will admit that it is mostly Claude who made this pull request so I will not be offended for any feedback or rejection. 😄 